### PR TITLE
Add steep_angle_multiplier to Fix Incorrect Edges at Grazing Angles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_edge_detection"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["AllenPocketGamer <allenpocketwork@gmail.com>"]

--- a/examples/3d_shapes.rs
+++ b/examples/3d_shapes.rs
@@ -220,6 +220,10 @@ fn edge_detection_ui(mut ctx: EguiContexts, mut edge_detection: Single<&mut Edge
                 egui::Slider::new(&mut edge_detection.steep_angle_threshold, 0.0..=1.0)
                     .text("steep_angle_threshold"),
             );
+            ui.add(
+                egui::Slider::new(&mut edge_detection.steep_angle_multiplier, 0.0..=1.0)
+                    .text("steep_angle_multiplier"),
+            );
         });
     });
 }

--- a/src/edge_detection.wgsl
+++ b/src/edge_detection.wgsl
@@ -108,21 +108,21 @@ fn view_z_gradient_y(pixel_coord: vec2i, x: i32) -> f32 {
 }
 
 fn detect_edge_depth(pixel_coord: vec2i, fresnel: f32) -> f32 {
-    let grad_x = 
+    let deri_x = 
         view_z_gradient_x(pixel_coord,  1) +
         2.0 * view_z_gradient_x(pixel_coord,  0) +
         view_z_gradient_x(pixel_coord, -1);
 
-    let grad_y =
+    let deri_y =
         view_z_gradient_y(pixel_coord, 1) +
         2.0 * view_z_gradient_y(pixel_coord, 0) +
         view_z_gradient_y(pixel_coord, -1);
 
-    // why not `let grad = sqrt(grad_x * grad_x + grad_y * grad_y);`?
+    // why not `let grad = sqrt(deri_x * deri_x + deri_y * deri_y);`?
     //
-    // Because ·grad_x· or ·grad_y· might be too large,
+    // Because ·deri_x· or ·deri_y· might be too large,
     // causing overflow in the calculation and resulting in incorrect results.
-    let grad = max(abs(grad_x), abs(grad_y));
+    let grad = max(abs(deri_x), abs(deri_y));
 
     let view_z = abs(prepass_view_z(pixel_coord));
 
@@ -165,18 +165,18 @@ fn normal_gradient_y(pixel_coord: vec2i, x: i32) -> vec3f {
 }
 
 fn detect_edge_normal(pixel_coord: vec2i) -> f32 {
-    let grad_x = abs(
+    let deri_x = abs(
         normal_gradient_x(pixel_coord,  1) +
         2.0 * normal_gradient_x(pixel_coord,  0) +
         normal_gradient_x(pixel_coord, -1));
 
-    let grad_y = abs(
+    let deri_y = abs(
         normal_gradient_y(pixel_coord, 1) +
         2.0 * normal_gradient_y(pixel_coord, 0) +
         normal_gradient_y(pixel_coord, -1));
 
-    let x_max = max(grad_x.x, max(grad_x.y, grad_x.z));
-    let y_max = max(grad_y.x, max(grad_y.y, grad_y.z));
+    let x_max = max(deri_x.x, max(deri_x.y, deri_x.z));
+    let y_max = max(deri_y.x, max(deri_y.y, deri_y.z));
     
     let grad = max(x_max, y_max);
 
@@ -206,17 +206,17 @@ fn color_gradient_y(pixel_coord: vec2i, x: i32) -> vec3f {
 }
 
 fn detect_edge_color(pixel_coord: vec2i) -> f32 {
-    let grad_x = 
+    let deri_x = 
         color_gradient_x(pixel_coord,  1) +
         2.0 * color_gradient_x(pixel_coord,  0) +
         color_gradient_x(pixel_coord, -1);
 
-    let grad_y =
+    let deri_y =
         color_gradient_y(pixel_coord, 1) +
         2.0 * color_gradient_y(pixel_coord, 0) +
         color_gradient_y(pixel_coord, -1);
 
-    let grad = max(length(grad_x), length(grad_y));
+    let grad = max(length(deri_x), length(deri_y));
 
     return f32(grad > ed_uniform.color_threshold);
 }

--- a/src/edge_detection.wgsl
+++ b/src/edge_detection.wgsl
@@ -31,6 +31,7 @@ struct EdgeDetectionUniform {
     color_threshold: f32,
     
     steep_angle_threshold: f32,
+    steep_angle_multiplier: f32,
 
     edge_color: vec4f,
 }
@@ -106,7 +107,7 @@ fn view_z_gradient_y(pixel_coord: vec2i, x: i32) -> f32 {
     return prepass_view_z(t_coord) - prepass_view_z(d_coord);
 }
 
-fn detect_edge_depth(pixel_coord: vec2i, steep_angle_adjustment: f32) -> f32 {
+fn detect_edge_depth(pixel_coord: vec2i, fresnel: f32) -> f32 {
     let grad_x = 
         view_z_gradient_x(pixel_coord,  1) +
         2.0 * view_z_gradient_x(pixel_coord,  0) +
@@ -122,6 +123,11 @@ fn detect_edge_depth(pixel_coord: vec2i, steep_angle_adjustment: f32) -> f32 {
     // Because ·grad_x· or ·grad_y· might be too large,
     // causing overflow in the calculation and resulting in incorrect results.
     let grad = max(abs(grad_x), abs(grad_y));
+
+    let view_z = abs(prepass_view_z(pixel_coord));
+
+    let steep_angle_adjustment = 
+        smoothstep(ed_uniform.steep_angle_threshold, 1.0, fresnel) * ed_uniform.steep_angle_multiplier * view_z;
 
     return f32(grad > ed_uniform.depth_threshold * (1.0 + steep_angle_adjustment));
 }
@@ -158,7 +164,7 @@ fn normal_gradient_y(pixel_coord: vec2i, x: i32) -> vec3f {
     return prepass_normal(t_coord) - prepass_normal(d_coord);
 }
 
-fn detect_edge_normal(pixel_coord: vec2i, steep_angle_adjustment: f32) -> f32 {
+fn detect_edge_normal(pixel_coord: vec2i) -> f32 {
     let grad_x = abs(
         normal_gradient_x(pixel_coord,  1) +
         2.0 * normal_gradient_x(pixel_coord,  0) +
@@ -174,7 +180,7 @@ fn detect_edge_normal(pixel_coord: vec2i, steep_angle_adjustment: f32) -> f32 {
     
     let grad = max(x_max, y_max);
 
-    return f32(grad > ed_uniform.normal_threshold * (1.0 - steep_angle_adjustment));
+    return f32(grad > ed_uniform.normal_threshold);
 }
 
 // ----------------------
@@ -235,25 +241,27 @@ fn fragment(
 
     let view_direction = calculate_view(world_position);
     let normal = prepass_normal_unpack(pixel_coord);
-    let fresnel = 1.0 - saturate(dot(normal, view_direction));
-    let steep_angle_adjustment = smoothstep(ed_uniform.steep_angle_threshold, 1.0, fresnel);
+    let fresnel = 1.0 - saturate(dot(normal, view_direction));;
 
     var edge = 0.0;
 
 #ifdef ENABLE_DEPTH
-    edge = max(edge, detect_edge_depth(pixel_coord, steep_angle_adjustment));
+    let edge_depth = detect_edge_depth(pixel_coord, fresnel);
+    edge = max(edge, edge_depth);
 #endif
 
 #ifdef ENABLE_NORMAL
-    edge = max(edge, detect_edge_normal(pixel_coord, steep_angle_adjustment));
+    let edge_normal = detect_edge_normal(pixel_coord);
+    edge = max(edge, edge_normal);
 #endif
 
 #ifdef ENABLE_COLOR
-    edge = max(edge, detect_edge_color(pixel_coord));
+    let edge_color = detect_edge_color(pixel_coord);
+    edge = max(edge, edge_color);
 #endif
 
     var color = textureSample(screen_texture, texture_sampler, in.uv).rgb;
     color = mix(color, ed_uniform.edge_color.rgb, edge);
 
-    return vec4f(vec3f(color), 1.0);
+    return vec4f(color, 1.0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ impl SpecializedRenderPipeline for EdgeDetectionPipeline {
             layout: vec![self.bind_group_layout(key.multisampled).clone()],
             vertex: fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
-                shader: self.shader.clone(),
+                shader: EDGE_DETECTION_SHADER_HANDLE,
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ impl SpecializedRenderPipeline for EdgeDetectionPipeline {
             layout: vec![self.bind_group_layout(key.multisampled).clone()],
             vertex: fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
-                shader: EDGE_DETECTION_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets,
@@ -301,6 +301,15 @@ pub struct EdgeDetection {
     ///
     /// Range: [0.0, 1.0]
     pub steep_angle_threshold: f32,
+    /// Multiplier applied to the depth threshold when the view angle is steep.
+    /// When the angle between the view direction and the surface normal exceeds the `steep_angle_threshold`,
+    /// the depth threshold is scaled by this multiplier to reduce the likelihood of false edge detection.
+    ///
+    /// A value of 1.0 means no adjustment, while values greater than 1.0 increase the depth threshold,
+    /// making edge detection less sensitive in steep angles.
+    ///
+    /// Range: [0.0, inf)
+    pub steep_angle_multiplier: f32,
 
     /// Edge color, used to draw the detected edges.
     /// Typically a high-contrast color (e.g., red or black) to visually highlight the edges.
@@ -326,7 +335,8 @@ impl Default for EdgeDetection {
 
             edge_color: Color::BLACK,
 
-            steep_angle_threshold: 0.5,
+            steep_angle_threshold: 0.0,
+            steep_angle_multiplier: 0.15,
 
             enable_depth: true,
             enable_normal: true,
@@ -341,6 +351,7 @@ pub struct EdgeDetectionUniform {
     pub normal_threshold: f32,
     pub color_threshold: f32,
     pub steep_angle_threshold: f32,
+    pub steep_angle_multiplier: f32,
     pub edge_color: LinearRgba,
 }
 
@@ -373,6 +384,7 @@ impl From<&EdgeDetection> for EdgeDetectionUniform {
             normal_threshold: ed.normal_threshold,
             color_threshold: ed.color_threshold,
             steep_angle_threshold: ed.steep_angle_threshold,
+            steep_angle_multiplier: ed.steep_angle_multiplier,
             edge_color: ed.edge_color.into(),
         }
     }


### PR DESCRIPTION
This PR adds the steep_angle_multiplier parameter to address the issue of incorrect black edges caused by grazing angles. When the angle between the view direction and the surface normal is very steep, the depth gradient can become artificially large, leading to non-edge regions being mistakenly detected as edges. By introducing steep_angle_multiplier, the depth threshold can be dynamically adjusted at steep angles, reducing false detection and preventing incorrect black edges.