### PR TITLE
Use edge color alpha as well

### DIFF
--- a/src/edge_detection.wgsl
+++ b/src/edge_detection.wgsl
@@ -281,7 +281,7 @@ fn fragment(
 #endif
 
     var color = textureSample(screen_texture, texture_sampler, in.uv).rgb;
-    color = mix(color, ed_uniform.edge_color.rgb, edge);
+    color = mix(color, ed_uniform.edge_color.rgb, edge * ed_uniform.edge_color.a);
 
     return vec4f(color, 1.0);
 }


### PR DESCRIPTION
Use edge color alpha slightly differently where it "burns" it into the existing color more, instead of overwriting entirely.